### PR TITLE
add blog content to rss feed

### DIFF
--- a/content/rss.py
+++ b/content/rss.py
@@ -14,6 +14,10 @@ def rss_entry(blog):
     ans+= "<guid isPermaLink=\"true\">"+blog["permalink"]+"</guid>"
     if "Summary" in blog:
         ans+= "<description>"+blog["Summary"]+"</description>"
+    if "Content" in blog:
+        with open(blog["Content"], "r") as f:
+            content = f.read()
+        ans += "<content:encoded><![CDATA[" + content + "]]></content:encoded>"
     ans += "<pubDate>" + datetime.strptime(blog["Date"],"%m/%d/%Y").strftime("%a, %d %b %Y %H:%M:%S %z EST") + "</pubDate>"
     ans += "</item>\n"
     return ans


### PR DESCRIPTION
This is a shot in the dark. I don't know how your build system works, so I wrote this raw.

It should look at a blog metadata like in `data/blog/angry.json`, read the contents of the file in the `Content` entry, and add it to the rss entry. The content is enclosed in `![CDATA[...]]>` to ensure that any special characters are properly escaped.

This may throw horrible errors, let me know.
