### PR TITLE
add blog content to rss feed

### DIFF
--- a/content/rss.py
+++ b/content/rss.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 
 def generate(data, index):
     ans = ""
@@ -14,6 +15,11 @@ def rss_entry(blog):
     ans+= "<guid isPermaLink=\"true\">"+blog["permalink"]+"</guid>"
     if "Summary" in blog:
         ans+= "<description>"+blog["Summary"]+"</description>"
+    if "Content" in blog:
+        content_path = os.path.join("content", blog["Content"])
+        with open(content_path, "r") as f:
+            content = f.read()
+        ans += "<content:encoded><![CDATA[" + content + "]]></content:encoded>"
     ans += "<pubDate>" + datetime.strptime(blog["Date"],"%m/%d/%Y").strftime("%a, %d %b %Y %H:%M:%S %z EST") + "</pubDate>"
     ans += "</item>\n"
     return ans


### PR DESCRIPTION
This is a shot in a dark. I'm not sure how the build system works, so this may throw horrible errors.

This change should read the blog metadata and add the blog content to the rss entry. The content is enclosed in `<![CDATA[...]]>` to ensure that any special characters are properly escaped.